### PR TITLE
docs: expand README and clarify API comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,18 @@ Note that persistent and remanent entries live in a DRAM image copied to the bac
 
 Write entries from anywhere. The second argument is a user defined code written into the event ID, and the last argument is a pointer to format arguments (`0` when the message has no runtime values).
 
+A log entry is a one-shot event, so call these on a transition rather than unconditionally in a cyclic body, which would write an entry every scan and churn the logbook.
+
 ```c
 void _CYCLIC ProgramCyclic(void)
 {
-	logInfo("App", 0, "Machine started", 0);
-	logWarning("App", 100, "Infeed sensor blocked", 0);
-	logError("App", 200, "Drive fault, machine stopped", 0);
+	if (startEdge) logInfo("App", 0, "Machine started", 0);
+	if (blockedEdge) logWarning("App", 100, "Infeed sensor blocked", 0);
+	if (faultEdge) logError("App", 200, "Drive fault, machine stopped", 0);
 }
 ```
+
+Snippets below leave application variables undeclared unless the rendered output depends on them.
 
 To include runtime values, fill in a `StrExtArgs_typ` and pass its address. Each specifier consumes the next unused member of the matching type: `%i`/`%d` from `i[]`, `%r`/`%f` from `r[]`, `%s` from `s[]` (string addresses), and `%b` from `b[]`. There are five members of each type, and a sixth specifier of the same type is dropped from the message without an error.
 
@@ -63,12 +67,16 @@ Logbooks are stored as Automation Runtime modules and share one namespace with e
 A logbook that outlives the restart which reran `_INIT` is still there the next time `createLogInit` runs, so the create reports `arEVENTLOG_ERR_LOGBOOK_EXISTS` (-1070586095). `LOG_PERSISTENCE_PERSIST` survives a cold restart and `LOG_PERSISTENCE_REMANENT` survives a warm one, so with either of those this is the normal case rather than an error:
 
 ```c
+// Global: gLogCreateStatus : DINT
+
 void _INIT ProgramInit(void)
 {
 	DINT status = createLogInit("App", 100000, LOG_PERSISTENCE_PERSIST);
 
 	if (status != 0 && status != arEVENTLOG_ERR_LOGBOOK_EXISTS) {
-		// Create failed for a real reason, most likely a name collision
+		// Unexpected, not necessarily fatal. Record it and confirm on the
+		//  first write. A name collision shows up here
+		gLogCreateStatus = status;
 	}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -42,6 +42,20 @@ logWarning("App", 300, "Recipe %s reported %i faults", (UDINT)&msgData);
 
 Every function returns a status. `0` means the entry was written; `LOG_ERR_INVALIDINPUT` (58300) means a required input was missing, and any other value is passed through from ArEventLog (most often because the logbook has not been created).
 
+# Naming a logbook
+
+Logbooks are stored as Automation Runtime modules and share one namespace with every other module on the target, including the tasks and programs in the project. Creating a logbook named after an existing task fails with `arEVENTLOG_ERR_MODULE_EXISTS` (-1070586084) and no logbook is created, so every later write fails too. Pick a name that is not a task, program, or module name, keep it within 8 characters, and do not start it with `$`.
+
+On a restart, a logbook created with `LOG_PERSISTENCE_REMANENT` or `LOG_PERSISTENCE_PERSIST` is still there, so `createLogInit` returns `arEVENTLOG_ERR_LOGBOOK_EXISTS` (-1070586095). That is expected and not a failure:
+
+```c
+DINT status = createLogInit("App", 1000000, LOG_PERSISTENCE_PERSIST);
+
+if (status == 0 || status == arEVENTLOG_ERR_LOGBOOK_EXISTS) {
+	// Logbook is ready to use
+}
+```
+
 # Dependencies
 - ArEventLog and AsBrStr, both shipped with Automation Studio
 - Loupe's [StringExt](https://github.com/loupeteam/StringExt) library, used for message formatting

--- a/README.md
+++ b/README.md
@@ -30,20 +30,23 @@ logWarning("App", 100, "Infeed sensor blocked", 0);
 logError("App", 200, "Drive fault, machine stopped", 0);
 ```
 
-To include runtime values, fill in a `StrExtArgs_typ` and pass its address. Each specifier consumes the next unused member of the matching type: `%i`/`%d` from `i[]`, `%r`/`%f` from `r[]`, `%s` from `s[]` (string addresses), and `%b` from `b[]`. There are five members of each type, and a sixth specifier of the same type is dropped from the message without an error.
+To include runtime values, fill in a `StrExtArgs_typ` and pass its address. Each specifier consumes the next unused member of the matching type: `%i`/`%d` from `i[]`, `%r`/`%f` from `r[]`, `%s` from `s[]` (string addresses), and `%b` from `b[]`. There are five members of each type, and a sixth specifier of the same type is dropped from the message without an error. Use `%%` for a literal percent sign: an unrecognized specifier is silently dropped along with the character after it, so a stray `%` in operator text eats the next character.
 
 ```c
-unsigned short errorCount = 3;
-plcstring recipeName[32] = "Widget";
+void _CYCLIC ProgramCyclic(void)
+{
+	unsigned short errorCount = 3;
+	plcstring recipeName[32] = "Widget";
 
-StrExtArgs_typ msgData;
-memset(&msgData, 0, sizeof(msgData));
+	StrExtArgs_typ msgData;
+	memset(&msgData, 0, sizeof(msgData));
 
-msgData.i[0] = errorCount;
-msgData.s[0] = (UDINT)recipeName;
+	msgData.i[0] = errorCount;
+	msgData.s[0] = (UDINT)recipeName;
 
-logWarning("App", 300, "Recipe %s reported %i faults", (UDINT)&msgData);
-// -> "Recipe Widget reported 3 faults"
+	logWarning("App", 300, "Recipe %s reported %i faults", (UDINT)&msgData);
+	// -> "Recipe Widget reported 3 faults"
+}
 ```
 
 The log functions return a status. `0` means the entry was written; `LOG_ERR_INVALIDINPUT` (58300) means a required input was missing, and any other value is passed through from ArEventLog (most often because the logbook has not been created).
@@ -55,10 +58,14 @@ Logbooks are stored as Automation Runtime modules and share one namespace with e
 A logbook that outlives the restart which reran `_INIT` is still there the next time `createLogInit` runs, so the create reports `arEVENTLOG_ERR_LOGBOOK_EXISTS` (-1070586095). `LOG_PERSISTENCE_PERSIST` survives a cold restart and `LOG_PERSISTENCE_REMANENT` survives a warm one, so with either of those this is the normal case rather than an error:
 
 ```c
-DINT status = createLogInit("App", 100000, LOG_PERSISTENCE_PERSIST);
+void _INIT ProgramInit(void)
+{
+	DINT status = createLogInit("App", 100000, LOG_PERSISTENCE_PERSIST);
 
-if (status == 0 || status == arEVENTLOG_ERR_LOGBOOK_EXISTS) {
-	// Logbook is ready to use
+	if (status == 0 || status == arEVENTLOG_ERR_LOGBOOK_EXISTS) {
+		// Create was accepted, confirm on the first write
+		gLogReady = 1;
+	}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ void _INIT ProgramInit(void)
 }
 ```
 
-`createLogInit` calls `ArEventLogCreate` once and returns that call's status rather than polling the function block to completion, and B&R documents `ArEventLogCreate` as asynchronous. Treat an unexpected status here as a prompt to check the status of the first write, which is where a missing logbook shows up unambiguously.
+B&R documents `ArEventLogCreate` as asynchronous, and `createLogInit` calls it once without polling it to completion. In an `_INIT` routine it finishes within that call, so the logbook is usable by the time the next statement runs and the returned status is the final result.
+
+A failed create is otherwise silent: a logbook named `Application` (11 characters, past the Automation Runtime limit) simply never appears, and every later write to it fails.
 
 # Dependencies
 - ArEventLog and AsBrStr, both shipped with Automation Studio

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ For more documentation and examples, see https://loupeteam.github.io/LoupeDocs/l
 
 # Quick start
 
-Create the logbook once from an `_INIT` routine. Names are limited to 8 characters and the log data area is 4096 bytes minimum.
+Create the logbook once from an `_INIT` routine. Names are limited to 8 characters and the log data area is 4096 bytes minimum. Use `LOG_PERSISTENCE_PERSIST` unless you have a reason not to: log entries matter most after the restart that followed the problem, and a volatile logbook is empty by then.
 
 ```c
 void _INIT ProgramInit(void)
 {
-	createLogInit("App", 1000000, LOG_PERSISTENCE_VOLATILE);
+	createLogInit("App", 1000000, LOG_PERSISTENCE_PERSIST);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,12 +25,17 @@ Note that persistent and remanent entries live in a DRAM image copied to the bac
 Write entries from anywhere. The second argument is a user defined code written into the event ID, and the last argument is a pointer to format arguments (`0` when the message has no runtime values).
 
 ```c
-logInfo("App", 0, "Machine started", 0);
-logWarning("App", 100, "Infeed sensor blocked", 0);
-logError("App", 200, "Drive fault, machine stopped", 0);
+void _CYCLIC ProgramCyclic(void)
+{
+	logInfo("App", 0, "Machine started", 0);
+	logWarning("App", 100, "Infeed sensor blocked", 0);
+	logError("App", 200, "Drive fault, machine stopped", 0);
+}
 ```
 
-To include runtime values, fill in a `StrExtArgs_typ` and pass its address. Each specifier consumes the next unused member of the matching type: `%i`/`%d` from `i[]`, `%r`/`%f` from `r[]`, `%s` from `s[]` (string addresses), and `%b` from `b[]`. There are five members of each type, and a sixth specifier of the same type is dropped from the message without an error. Use `%%` for a literal percent sign: an unrecognized specifier is silently dropped along with the character after it, so a stray `%` in operator text eats the next character.
+To include runtime values, fill in a `StrExtArgs_typ` and pass its address. Each specifier consumes the next unused member of the matching type: `%i`/`%d` from `i[]`, `%r`/`%f` from `r[]`, `%s` from `s[]` (string addresses), and `%b` from `b[]`. There are five members of each type, and a sixth specifier of the same type is dropped from the message without an error.
+
+Formatting happens only when `pMsgData` is non-zero. With `0` the message is written to the logger verbatim, percent signs included. When you do pass arguments, use `%%` for a literal percent: an unrecognized `%` is dropped together with the single character that follows it, so a stray `%` in operator text eats the next character.
 
 ```c
 void _CYCLIC ProgramCyclic(void)
@@ -62,9 +67,8 @@ void _INIT ProgramInit(void)
 {
 	DINT status = createLogInit("App", 100000, LOG_PERSISTENCE_PERSIST);
 
-	if (status == 0 || status == arEVENTLOG_ERR_LOGBOOK_EXISTS) {
-		// Create was accepted, confirm on the first write
-		gLogReady = 1;
+	if (status != 0 && status != arEVENTLOG_ERR_LOGBOOK_EXISTS) {
+		// Create failed for a real reason, most likely a name collision
 	}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Note that persistent and remanent entries live in a DRAM image copied to the bac
 
 Write entries from anywhere. The second argument is a user defined code written into the event ID, and the last argument is a pointer to format arguments (`0` when the message has no runtime values).
 
-A log entry is a one-shot event, so call these on a transition rather than unconditionally in a cyclic body, which would write an entry every scan and churn the logbook.
+A log entry is a one-shot event, so call these on a transition rather than unconditionally in a cyclic body, which would write an entry every scan and churn the logbook. Application variables such as the edge flags below are not declared in these snippets.
 
 ```c
 void _CYCLIC ProgramCyclic(void)
@@ -34,8 +34,6 @@ void _CYCLIC ProgramCyclic(void)
 	if (faultEdge) logError("App", 200, "Drive fault, machine stopped", 0);
 }
 ```
-
-Snippets below leave application variables undeclared unless the rendered output depends on them.
 
 To include runtime values, fill in a `StrExtArgs_typ` and pass its address. Each specifier consumes the next unused member of the matching type: `%i`/`%d` from `i[]`, `%r`/`%f` from `r[]`, `%s` from `s[]` (string addresses), and `%b` from `b[]`. There are five members of each type, and a sixth specifier of the same type is dropped from the message without an error.
 
@@ -48,13 +46,16 @@ void _CYCLIC ProgramCyclic(void)
 	plcstring recipeName[32] = "Widget";
 
 	StrExtArgs_typ msgData;
-	memset(&msgData, 0, sizeof(msgData));
 
-	msgData.i[0] = errorCount;
-	msgData.s[0] = (UDINT)recipeName;
+	if (faultEdge) {
+		memset(&msgData, 0, sizeof(msgData));
 
-	logWarning("App", 300, "Recipe %s reported %i faults", (UDINT)&msgData);
-	// -> "Recipe Widget reported 3 faults"
+		msgData.i[0] = errorCount;
+		msgData.s[0] = (UDINT)recipeName;
+
+		logWarning("App", 300, "Recipe %s reported %i faults", (UDINT)&msgData);
+		// -> "Recipe Widget reported 3 faults"
+	}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,46 @@ info@loupe.team
 1-800-240-7042  
 
 # Description
-LogThat provides a easy to use interface for adding diagnostic information into the CPU’s Logger. To use LogThat’s full functionality, a template of type StrExtArgs_typ will need to be declared.
+LogThat provides an easy to use interface for adding diagnostic information into the CPU's logger. It wraps B&R's ArEventLog library so creating a logbook takes one line in `_INIT` and writing an entry takes a single function call. Messages can include runtime values through a printf-style format string, using `StrExtArgs_typ` from Loupe's StringExt library.
 
 For more documentation and examples, see https://loupeteam.github.io/LoupeDocs/libraries/logthat.html
+
+# Quick start
+
+Create the logbook once from an `_INIT` routine. Names are limited to 8 characters and the log data area is 4096 bytes minimum.
+
+```c
+void _INIT ProgramInit(void)
+{
+	createLogInit("App", 1000000, LOG_PERSISTENCE_VOLATILE);
+}
+```
+
+Write entries from anywhere. The second argument is a user defined code written into the event ID, and the last argument is a pointer to format arguments (`0` when the message has no runtime values).
+
+```c
+logInfo("App", 0, "Machine started", 0);
+logWarning("App", 100, "Infeed sensor blocked", 0);
+logError("App", 200, "Drive fault, machine stopped", 0);
+```
+
+To include runtime values, fill in a `StrExtArgs_typ` and pass its address. Each specifier consumes the next unused member of the matching type: `%i`/`%d` from `i[]`, `%r`/`%f` from `r[]`, `%s` from `s[]` (string addresses), and `%b` from `b[]`.
+
+```c
+StrExtArgs_typ msgData;
+memset(&msgData, 0, sizeof(msgData));
+
+msgData.i[0] = errorCount;
+msgData.s[0] = (UDINT)&recipeName;
+
+logWarning("App", 300, "Recipe %s reported %i faults", (UDINT)&msgData);
+```
+
+Every function returns a status. `0` means the entry was written; `LOG_ERR_INVALIDINPUT` (58300) means a required input was missing, and any other value is passed through from ArEventLog (most often because the logbook has not been created).
+
+# Dependencies
+- ArEventLog and AsBrStr, both shipped with Automation Studio
+- Loupe's [StringExt](https://github.com/loupeteam/StringExt) library, used for message formatting
 
 # Installation
 To install using the Loupe Package Manager (LPM), in an initialized Automation Studio project directory run `lpm install logthat`. For more information about LPM, see https://loupeteam.github.io/LoupeDocs/tools/lpm.html

--- a/README.md
+++ b/README.md
@@ -11,14 +11,16 @@ For more documentation and examples, see https://loupeteam.github.io/LoupeDocs/l
 
 # Quick start
 
-Create the logbook once from an `_INIT` routine. Names are limited to 8 characters and the log data area is 4096 bytes minimum. Use `LOG_PERSISTENCE_PERSIST` unless you have a reason not to: log entries matter most after the restart that followed the problem, and a volatile logbook is empty by then.
+Create the logbook once from an `_INIT` routine. Names are limited to 8 characters, and the log data area is 4096 bytes minimum (passing `0` uses `LOG_DEFAULT_LOGGERSIZE`, 100000). Use `LOG_PERSISTENCE_PERSIST` unless you have a reason not to: log entries matter most after the restart that followed the problem, and a volatile logbook is empty by then.
 
 ```c
 void _INIT ProgramInit(void)
 {
-	createLogInit("App", 1000000, LOG_PERSISTENCE_PERSIST);
+	createLogInit("App", 100000, LOG_PERSISTENCE_PERSIST);
 }
 ```
+
+Note that persistent and remanent entries live in a DRAM image copied to the backing memory every 60 seconds and on an orderly shutdown, so up to a minute of entries can still be lost to a power fail or watchdog reset.
 
 Write entries from anywhere. The second argument is a user defined code written into the event ID, and the last argument is a pointer to format arguments (`0` when the message has no runtime values).
 
@@ -28,40 +30,46 @@ logWarning("App", 100, "Infeed sensor blocked", 0);
 logError("App", 200, "Drive fault, machine stopped", 0);
 ```
 
-To include runtime values, fill in a `StrExtArgs_typ` and pass its address. Each specifier consumes the next unused member of the matching type: `%i`/`%d` from `i[]`, `%r`/`%f` from `r[]`, `%s` from `s[]` (string addresses), and `%b` from `b[]`.
+To include runtime values, fill in a `StrExtArgs_typ` and pass its address. Each specifier consumes the next unused member of the matching type: `%i`/`%d` from `i[]`, `%r`/`%f` from `r[]`, `%s` from `s[]` (string addresses), and `%b` from `b[]`. There are five members of each type, and a sixth specifier of the same type is dropped from the message without an error.
 
 ```c
+unsigned short errorCount = 3;
+plcstring recipeName[32] = "Widget";
+
 StrExtArgs_typ msgData;
 memset(&msgData, 0, sizeof(msgData));
 
 msgData.i[0] = errorCount;
-msgData.s[0] = (UDINT)&recipeName;
+msgData.s[0] = (UDINT)recipeName;
 
 logWarning("App", 300, "Recipe %s reported %i faults", (UDINT)&msgData);
+// -> "Recipe Widget reported 3 faults"
 ```
 
-Every function returns a status. `0` means the entry was written; `LOG_ERR_INVALIDINPUT` (58300) means a required input was missing, and any other value is passed through from ArEventLog (most often because the logbook has not been created).
+The log functions return a status. `0` means the entry was written; `LOG_ERR_INVALIDINPUT` (58300) means a required input was missing, and any other value is passed through from ArEventLog (most often because the logbook has not been created).
 
 # Naming a logbook
 
 Logbooks are stored as Automation Runtime modules and share one namespace with every other module on the target, including the tasks and programs in the project. Creating a logbook named after an existing task fails with `arEVENTLOG_ERR_MODULE_EXISTS` (-1070586084) and no logbook is created, so every later write fails too. Pick a name that is not a task, program, or module name, keep it within 8 characters, and do not start it with `$`.
 
-On a restart, a logbook created with `LOG_PERSISTENCE_REMANENT` or `LOG_PERSISTENCE_PERSIST` is still there, so `createLogInit` returns `arEVENTLOG_ERR_LOGBOOK_EXISTS` (-1070586095). That is expected and not a failure:
+A logbook that outlives the restart which reran `_INIT` is still there the next time `createLogInit` runs, so the create reports `arEVENTLOG_ERR_LOGBOOK_EXISTS` (-1070586095). `LOG_PERSISTENCE_PERSIST` survives a cold restart and `LOG_PERSISTENCE_REMANENT` survives a warm one, so with either of those this is the normal case rather than an error:
 
 ```c
-DINT status = createLogInit("App", 1000000, LOG_PERSISTENCE_PERSIST);
+DINT status = createLogInit("App", 100000, LOG_PERSISTENCE_PERSIST);
 
 if (status == 0 || status == arEVENTLOG_ERR_LOGBOOK_EXISTS) {
 	// Logbook is ready to use
 }
 ```
 
+`createLogInit` calls `ArEventLogCreate` once and returns that call's status rather than polling the function block to completion, and B&R documents `ArEventLogCreate` as asynchronous. Treat an unexpected status here as a prompt to check the status of the first write, which is where a missing logbook shows up unambiguously.
+
 # Dependencies
 - ArEventLog and AsBrStr, both shipped with Automation Studio
 - Loupe's [StringExt](https://github.com/loupeteam/StringExt) library, used for message formatting
 
 # Installation
-To install using the Loupe Package Manager (LPM), in an initialized Automation Studio project directory run `lpm install logthat`. For more information about LPM, see https://loupeteam.github.io/LoupeDocs/tools/lpm.html
+To install using the Loupe Package Manager (LPM), in an initialized Automation Studio project directory run `lpm install logthat`. LogThat's package does not declare StringExt as an LPM dependency, so install it as well with `lpm install stringext` if the project does not already have it. For more information about LPM, see https://loupeteam.github.io/LoupeDocs/tools/lpm.html
 
 ## Licensing
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The log functions return a status. `0` means the entry was written; `LOG_ERR_INV
 
 Logbooks are stored as Automation Runtime modules and share one namespace with every other module on the target, including the tasks and programs in the project. Creating a logbook named after an existing task fails with `arEVENTLOG_ERR_MODULE_EXISTS` (-1070586084) and no logbook is created, so every later write fails too. Pick a name that is not a task, program, or module name, keep it within 8 characters, and do not start it with `$`.
 
-A logbook that outlives the restart which reran `_INIT` is still there the next time `createLogInit` runs, so the create reports `arEVENTLOG_ERR_LOGBOOK_EXISTS` (-1070586095). `LOG_PERSISTENCE_PERSIST` survives a cold restart and `LOG_PERSISTENCE_REMANENT` survives a warm one, so with either of those this is the normal case rather than an error:
+A logbook that outlives the restart which reran `_INIT` is still there the next time `createLogInit` runs, so the create reports `arEVENTLOG_ERR_LOGBOOK_EXISTS` (-1070586095). `LOG_PERSISTENCE_PERSIST` survives a cold restart, so this is the normal case on every boot after the first. `LOG_PERSISTENCE_REMANENT` survives a warm restart only, so it is the normal case after one of those and the logbook is created fresh after a cold restart:
 
 ```c
 // Global: gLogCreateStatus : DINT

--- a/src/Ar/LogThat/CHANGELOG.md
+++ b/src/Ar/LogThat/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+- 1.0.0 - Update the example project for AS6: remove the deprecated AsDb and Motion libraries
+    - Update StringExt in the example project to a released version
+    - Add package.json so the library can be installed with LPM
 - 0.05.1 - Rename problematic 'delete' internal var to 'deletion' (to avoid C++ keyword conflict in older AS versions)
 - 0.05.0 - Remove constants: LOG_DEFAULT_MESSAGESIZE, LOG_DEFAULT_BUFFEREDENTRIES
     - Remove ManageLoggers Fn

--- a/src/Ar/LogThat/CHANGELOG.md
+++ b/src/Ar/LogThat/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change log
 
-- 1.0.0 - Update the example project for AS6: remove the deprecated AsDb and Motion libraries
-    - Update StringExt in the example project to a released version
+- 1.0.0 - Raise the minimum StringExt version from 0.14.1 to 1.0.0
+    - Update the example project for AS6: remove AsArLog, AsDb, AsSafety, Convert, LoopConR, MTTypes and the Motion libraries, none of which the library uses
+    - Update StringExt in the example project to the released 1.0.0
     - Add package.json so the library can be installed with LPM
 - 0.05.1 - Rename problematic 'delete' internal var to 'deletion' (to avoid C++ keyword conflict in older AS versions)
 - 0.05.0 - Remove constants: LOG_DEFAULT_MESSAGESIZE, LOG_DEFAULT_BUFFEREDENTRIES

--- a/src/Ar/LogThat/LogThat.fun
+++ b/src/Ar/LogThat/LogThat.fun
@@ -6,19 +6,16 @@
  * This file is part of LogThat, licensed under the MIT License.
  *)
 
-(*!!!PRE-RELEASE!!!*)
-(*Proposed API*)
-
-FUNCTION_BLOCK logDelete
+FUNCTION_BLOCK logDelete (*Delete a logbook and all of its entries. Call cyclically until done or error, then clear execute*)
 	VAR_INPUT
-		name : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of logger to be deleted*)
-		execute : BOOL; (*Start deleting*)
+		name : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook to be deleted*)
+		execute : BOOL; (*Rising edge starts the delete*)
 	END_VAR
 	VAR_OUTPUT
-		done : BOOL; (*Done*)
-		busy : BOOL; (*Busy*)
-		error : BOOL; (*Error has occured*)
-		errorID : DINT; (*Error ID*)
+		done : BOOL; (*Delete finished successfully*)
+		busy : BOOL; (*Delete in progress*)
+		error : BOOL; (*An error has occurred*)
+		errorID : DINT; (*Status of the failed operation, passed through from ArEventLog*)
 	END_VAR
 	VAR
 		ident : ArEventLogGetIdent;
@@ -28,64 +25,63 @@ END_FUNCTION_BLOCK
 
 {REDUND_CONTEXT} FUNCTION createLogInit : DINT (*Only supported in INIT*)
 	VAR_INPUT
-		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook to be created*)
-		size : UDINT; (*Length of the log data area in bytes (min 4096)*)
-		persistence : LOG_PERSISTENCE_enum; (*Persistence of logbook*)
+		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook to be created (max 8 chars)*)
+		size : UDINT; (*Length of the log data area in bytes (min 4096). 0 uses LOG_DEFAULT_LOGGERSIZE*)
+		persistence : LOG_PERSISTENCE_enum; (*Where the entries are stored*)
 	END_VAR
 END_FUNCTION
 
 {REDUND_CONTEXT} FUNCTION logEventID : DINT (*Write an event message to the logger*)
 	VAR_INPUT
-		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Pointer to string containing name of logger for message to be added*)
-		eventID : DINT; (*Event ID containing severity, facility, and code*)
-		eventString : STRING[LOG_STRLEN_MESSAGE]; (*Event message*)
-		pMsgData : UDINT; (*Pointer to format arguments*)
+		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook the message is added to*)
+		eventID : DINT; (*Event ID containing severity, facility, and code. The customer bit is set internally*)
+		eventString : STRING[LOG_STRLEN_MESSAGE]; (*Event message, may contain formatters (%i %r %s %b)*)
+		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, or 0 for none*)
 	END_VAR
 END_FUNCTION
 
 {REDUND_CONTEXT} FUNCTION logSuccess : DINT (*Write a success message to the logger*)
 	VAR_INPUT
-		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Pointer to string containing name of logger for message to be added*)
-		errorID : UINT; (*Code for logger entry*)
-		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry*)
-		pMsgData : UDINT; (*Pointer to format arguments*)
+		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook the message is added to*)
+		errorID : UINT; (*User defined code written into the event ID*)
+		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, may contain formatters (%i %r %s %b)*)
+		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, or 0 for none*)
 	END_VAR
 END_FUNCTION
-(*Legacy*)
 
 {REDUND_CONTEXT} FUNCTION logWarning : DINT (*Write a warning message to the logger*) (*$GROUP=User,$CAT=User,$GROUPICON=User.png,$CATICON=User.png*)
 	VAR_INPUT
-		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Pointer to string containing name of logger for message to be added*)
-		errorID : UINT; (*Code for logger entry*)
-		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry*)
-		pMsgData : UDINT; (*Pointer to format arguments*)
+		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook the message is added to*)
+		errorID : UINT; (*User defined code written into the event ID*)
+		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, may contain formatters (%i %r %s %b)*)
+		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, or 0 for none*)
 	END_VAR
 END_FUNCTION
 
 {REDUND_CONTEXT} FUNCTION logError : DINT (*Write a fatal error message to the logger*) (*$GROUP=User,$CAT=User,$GROUPICON=User.png,$CATICON=User.png*)
 	VAR_INPUT
-		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Pointer to string containing name of logger for message to be added*)
-		errorID : UINT; (*Code for logger entry*)
-		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry*)
-		pMsgData : UDINT; (*Pointer to format arguments*)
+		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook the message is added to*)
+		errorID : UINT; (*User defined code written into the event ID*)
+		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, may contain formatters (%i %r %s %b)*)
+		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, or 0 for none*)
 	END_VAR
 END_FUNCTION
 
 {REDUND_CONTEXT} FUNCTION logInfo : DINT (*Write an info message to the logger*) (*$GROUP=User,$CAT=User,$GROUPICON=User.png,$CATICON=User.png*)
 	VAR_INPUT
-		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Pointer to string containing name of logger for message to be added*)
-		errorID : UINT; (*Code for logger entry*)
-		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry*)
-		pMsgData : UDINT; (*Pointer to format arguments*)
+		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook the message is added to*)
+		errorID : UINT; (*User defined code written into the event ID*)
+		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, may contain formatters (%i %r %s %b)*)
+		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, or 0 for none*)
 	END_VAR
 END_FUNCTION
 
-{REDUND_CONTEXT} FUNCTION_BLOCK logStateChange (*pass in state value and logger name. *) (*$GROUP=User*)
+{REDUND_CONTEXT} FUNCTION_BLOCK logStateChange (*Log an info entry whenever State changes. Call cyclically*) (*$GROUP=User*)
 	VAR_INPUT
-		LoggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of logger for messages to be added*)
-		ModuleName : STRING[LOG_STRLEN_MODULENAME]; (*Name of module with state changes*)
+		LoggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of logger for messages to be added. Defaults to 'State' if empty on the first call*)
+		ModuleName : STRING[LOG_STRLEN_MODULENAME]; (*Name of module with state changes. Defaults to 'State' if empty on the first call*)
 		State : UDINT; (*Current state*)
-		StateName : STRING[LOG_STRLEN_STATENAME]; (*State name or description*)
+		StateName : STRING[LOG_STRLEN_STATENAME]; (*State name or description (optional)*)
 	END_VAR
 	VAR
 		oldState : UDINT;

--- a/src/Ar/LogThat/LogThat.fun
+++ b/src/Ar/LogThat/LogThat.fun
@@ -6,10 +6,10 @@
  * This file is part of LogThat, licensed under the MIT License.
  *)
 
-FUNCTION_BLOCK logDelete (*Delete a logbook and all of its entries. Call cyclically, holding execute until done or error, then clear it*)
+FUNCTION_BLOCK logDelete (*Delete a logbook and all of its entries. Call cyclically, holding execute until done or error, then clear it. Outputs follow the underlying ArEventLog FUBs on every call*)
 	VAR_INPUT
 		name : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook to be deleted*)
-		execute : BOOL; (*Hold TRUE until done or error. Clearing it early abandons the operation and resets the outputs*)
+		execute : BOOL; (*Hold TRUE until done or error. Clearing it early stops driving the delete without cancelling it*)
 	END_VAR
 	VAR_OUTPUT
 		done : BOOL; (*Delete finished successfully*)

--- a/src/Ar/LogThat/LogThat.fun
+++ b/src/Ar/LogThat/LogThat.fun
@@ -35,8 +35,8 @@ END_FUNCTION
 	VAR_INPUT
 		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook the message is added to*)
 		eventID : DINT; (*Event ID containing severity, facility, and code. The customer bit is set internally*)
-		eventString : STRING[LOG_STRLEN_MESSAGE]; (*Event message, may contain formatters (%i %d %r %f %s %b), %% for a literal percent*)
-		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, or 0 for none. Max 5 per type*)
+		eventString : STRING[LOG_STRLEN_MESSAGE]; (*Event message, when pMsgData is supplied it may contain formatters (%i %d %r %f %s %b), and %% for a literal percent*)
+		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, max 5 of each type (i/r/s/b). 0 writes the message verbatim, with no formatting*)
 	END_VAR
 END_FUNCTION
 
@@ -44,8 +44,8 @@ END_FUNCTION
 	VAR_INPUT
 		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook the message is added to*)
 		errorID : UINT; (*User defined code written into the event ID*)
-		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, may contain formatters (%i %d %r %f %s %b), %% for a literal percent*)
-		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, or 0 for none. Max 5 per type*)
+		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, when pMsgData is supplied it may contain formatters (%i %d %r %f %s %b), and %% for a literal percent*)
+		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, max 5 of each type (i/r/s/b). 0 writes the message verbatim, with no formatting*)
 	END_VAR
 END_FUNCTION
 (*Legacy*)
@@ -54,8 +54,8 @@ END_FUNCTION
 	VAR_INPUT
 		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook the message is added to*)
 		errorID : UINT; (*User defined code written into the event ID*)
-		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, may contain formatters (%i %d %r %f %s %b), %% for a literal percent*)
-		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, or 0 for none. Max 5 per type*)
+		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, when pMsgData is supplied it may contain formatters (%i %d %r %f %s %b), and %% for a literal percent*)
+		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, max 5 of each type (i/r/s/b). 0 writes the message verbatim, with no formatting*)
 	END_VAR
 END_FUNCTION
 
@@ -63,8 +63,8 @@ END_FUNCTION
 	VAR_INPUT
 		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook the message is added to*)
 		errorID : UINT; (*User defined code written into the event ID*)
-		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, may contain formatters (%i %d %r %f %s %b), %% for a literal percent*)
-		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, or 0 for none. Max 5 per type*)
+		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, when pMsgData is supplied it may contain formatters (%i %d %r %f %s %b), and %% for a literal percent*)
+		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, max 5 of each type (i/r/s/b). 0 writes the message verbatim, with no formatting*)
 	END_VAR
 END_FUNCTION
 
@@ -72,8 +72,8 @@ END_FUNCTION
 	VAR_INPUT
 		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook the message is added to*)
 		errorID : UINT; (*User defined code written into the event ID*)
-		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, may contain formatters (%i %d %r %f %s %b), %% for a literal percent*)
-		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, or 0 for none. Max 5 per type*)
+		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, when pMsgData is supplied it may contain formatters (%i %d %r %f %s %b), and %% for a literal percent*)
+		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, max 5 of each type (i/r/s/b). 0 writes the message verbatim, with no formatting*)
 	END_VAR
 END_FUNCTION
 

--- a/src/Ar/LogThat/LogThat.fun
+++ b/src/Ar/LogThat/LogThat.fun
@@ -9,7 +9,7 @@
 FUNCTION_BLOCK logDelete (*Delete a logbook and all of its entries. Call cyclically until done or error, then clear execute*)
 	VAR_INPUT
 		name : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook to be deleted*)
-		execute : BOOL; (*Rising edge starts the delete*)
+		execute : BOOL; (*Hold TRUE until done or error. Clearing it aborts the delete*)
 	END_VAR
 	VAR_OUTPUT
 		done : BOOL; (*Delete finished successfully*)
@@ -35,7 +35,7 @@ END_FUNCTION
 	VAR_INPUT
 		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook the message is added to*)
 		eventID : DINT; (*Event ID containing severity, facility, and code. The customer bit is set internally*)
-		eventString : STRING[LOG_STRLEN_MESSAGE]; (*Event message, may contain formatters (%i %r %s %b)*)
+		eventString : STRING[LOG_STRLEN_MESSAGE]; (*Event message, may contain formatters (%i %d %r %f %s %b)*)
 		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, or 0 for none*)
 	END_VAR
 END_FUNCTION
@@ -44,16 +44,17 @@ END_FUNCTION
 	VAR_INPUT
 		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook the message is added to*)
 		errorID : UINT; (*User defined code written into the event ID*)
-		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, may contain formatters (%i %r %s %b)*)
+		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, may contain formatters (%i %d %r %f %s %b)*)
 		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, or 0 for none*)
 	END_VAR
 END_FUNCTION
+(*Legacy*)
 
 {REDUND_CONTEXT} FUNCTION logWarning : DINT (*Write a warning message to the logger*) (*$GROUP=User,$CAT=User,$GROUPICON=User.png,$CATICON=User.png*)
 	VAR_INPUT
 		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook the message is added to*)
 		errorID : UINT; (*User defined code written into the event ID*)
-		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, may contain formatters (%i %r %s %b)*)
+		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, may contain formatters (%i %d %r %f %s %b)*)
 		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, or 0 for none*)
 	END_VAR
 END_FUNCTION
@@ -62,7 +63,7 @@ END_FUNCTION
 	VAR_INPUT
 		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook the message is added to*)
 		errorID : UINT; (*User defined code written into the event ID*)
-		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, may contain formatters (%i %r %s %b)*)
+		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, may contain formatters (%i %d %r %f %s %b)*)
 		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, or 0 for none*)
 	END_VAR
 END_FUNCTION
@@ -71,12 +72,12 @@ END_FUNCTION
 	VAR_INPUT
 		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook the message is added to*)
 		errorID : UINT; (*User defined code written into the event ID*)
-		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, may contain formatters (%i %r %s %b)*)
+		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, may contain formatters (%i %d %r %f %s %b)*)
 		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, or 0 for none*)
 	END_VAR
 END_FUNCTION
 
-{REDUND_CONTEXT} FUNCTION_BLOCK logStateChange (*Log an info entry whenever State changes. Call cyclically*) (*$GROUP=User*)
+{REDUND_CONTEXT} FUNCTION_BLOCK logStateChange (*Log an info entry on the first call and whenever State changes after that. Call cyclically*) (*$GROUP=User*)
 	VAR_INPUT
 		LoggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of logger for messages to be added. Defaults to 'State' if empty on the first call*)
 		ModuleName : STRING[LOG_STRLEN_MODULENAME]; (*Name of module with state changes. Defaults to 'State' if empty on the first call*)

--- a/src/Ar/LogThat/LogThat.fun
+++ b/src/Ar/LogThat/LogThat.fun
@@ -48,7 +48,7 @@ END_FUNCTION
 		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, max 5 of each type (i/r/s/b). 0 writes the message verbatim, with no formatting*)
 	END_VAR
 END_FUNCTION
-(*Legacy*)
+(*Legacy: the severity functions below predate logEventID. They remain fully supported*)
 
 {REDUND_CONTEXT} FUNCTION logWarning : DINT (*Write a warning message to the logger*) (*$GROUP=User,$CAT=User,$GROUPICON=User.png,$CATICON=User.png*)
 	VAR_INPUT

--- a/src/Ar/LogThat/LogThat.fun
+++ b/src/Ar/LogThat/LogThat.fun
@@ -6,7 +6,7 @@
  * This file is part of LogThat, licensed under the MIT License.
  *)
 
-FUNCTION_BLOCK logDelete (*Delete a logbook and all of its entries. Call cyclically, holding execute until done or error, then clear it. Outputs follow the underlying ArEventLog FUBs on every call*)
+FUNCTION_BLOCK logDelete (*Delete a logbook and all of its entries. Call cyclically, holding execute until done or error, then clear it. Outputs keep following the underlying ArEventLog FUBs after execute is cleared*)
 	VAR_INPUT
 		name : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook to be deleted*)
 		execute : BOOL; (*Hold TRUE until done or error. Clearing it early stops driving the delete without cancelling it*)

--- a/src/Ar/LogThat/LogThat.fun
+++ b/src/Ar/LogThat/LogThat.fun
@@ -6,10 +6,10 @@
  * This file is part of LogThat, licensed under the MIT License.
  *)
 
-FUNCTION_BLOCK logDelete (*Delete a logbook and all of its entries. Call cyclically until done or error, then clear execute*)
+FUNCTION_BLOCK logDelete (*Delete a logbook and all of its entries. Call cyclically, holding execute until done or error, then clear it*)
 	VAR_INPUT
 		name : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook to be deleted*)
-		execute : BOOL; (*Hold TRUE until done or error. Clearing it aborts the delete*)
+		execute : BOOL; (*Hold TRUE until done or error. Clearing it early abandons the operation and resets the outputs*)
 	END_VAR
 	VAR_OUTPUT
 		done : BOOL; (*Delete finished successfully*)
@@ -35,8 +35,8 @@ END_FUNCTION
 	VAR_INPUT
 		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook the message is added to*)
 		eventID : DINT; (*Event ID containing severity, facility, and code. The customer bit is set internally*)
-		eventString : STRING[LOG_STRLEN_MESSAGE]; (*Event message, may contain formatters (%i %d %r %f %s %b)*)
-		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, or 0 for none*)
+		eventString : STRING[LOG_STRLEN_MESSAGE]; (*Event message, may contain formatters (%i %d %r %f %s %b), %% for a literal percent*)
+		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, or 0 for none. Max 5 per type*)
 	END_VAR
 END_FUNCTION
 
@@ -44,8 +44,8 @@ END_FUNCTION
 	VAR_INPUT
 		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook the message is added to*)
 		errorID : UINT; (*User defined code written into the event ID*)
-		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, may contain formatters (%i %d %r %f %s %b)*)
-		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, or 0 for none*)
+		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, may contain formatters (%i %d %r %f %s %b), %% for a literal percent*)
+		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, or 0 for none. Max 5 per type*)
 	END_VAR
 END_FUNCTION
 (*Legacy*)
@@ -54,8 +54,8 @@ END_FUNCTION
 	VAR_INPUT
 		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook the message is added to*)
 		errorID : UINT; (*User defined code written into the event ID*)
-		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, may contain formatters (%i %d %r %f %s %b)*)
-		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, or 0 for none*)
+		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, may contain formatters (%i %d %r %f %s %b), %% for a literal percent*)
+		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, or 0 for none. Max 5 per type*)
 	END_VAR
 END_FUNCTION
 
@@ -63,8 +63,8 @@ END_FUNCTION
 	VAR_INPUT
 		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook the message is added to*)
 		errorID : UINT; (*User defined code written into the event ID*)
-		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, may contain formatters (%i %d %r %f %s %b)*)
-		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, or 0 for none*)
+		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, may contain formatters (%i %d %r %f %s %b), %% for a literal percent*)
+		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, or 0 for none. Max 5 per type*)
 	END_VAR
 END_FUNCTION
 
@@ -72,15 +72,15 @@ END_FUNCTION
 	VAR_INPUT
 		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook the message is added to*)
 		errorID : UINT; (*User defined code written into the event ID*)
-		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, may contain formatters (%i %d %r %f %s %b)*)
-		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, or 0 for none*)
+		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, may contain formatters (%i %d %r %f %s %b), %% for a literal percent*)
+		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, or 0 for none. Max 5 per type*)
 	END_VAR
 END_FUNCTION
 
 {REDUND_CONTEXT} FUNCTION_BLOCK logStateChange (*Log an info entry on the first call and whenever State changes after that. Call cyclically*) (*$GROUP=User*)
 	VAR_INPUT
-		LoggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of logger for messages to be added. Defaults to 'State' if empty on the first call*)
-		ModuleName : STRING[LOG_STRLEN_MODULENAME]; (*Name of module with state changes. Defaults to 'State' if empty on the first call*)
+		LoggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of logger for messages to be added. If empty on the first call, 'State' is written back into this input, once only*)
+		ModuleName : STRING[LOG_STRLEN_MODULENAME]; (*Name of module with state changes. If empty on the first call, 'State' is written back into this input, once only*)
 		State : UDINT; (*Current state*)
 		StateName : STRING[LOG_STRLEN_STATENAME]; (*State name or description (optional)*)
 	END_VAR

--- a/src/Ar/LogThat/LogThat.fun
+++ b/src/Ar/LogThat/LogThat.fun
@@ -35,7 +35,7 @@ END_FUNCTION
 	VAR_INPUT
 		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook the message is added to*)
 		eventID : DINT; (*Event ID containing severity, facility, and code. The customer bit is set internally*)
-		eventString : STRING[LOG_STRLEN_MESSAGE]; (*Event message, when pMsgData is supplied it may contain formatters (%i %d %r %f %s %b), and %% for a literal percent*)
+		eventString : STRING[LOG_STRLEN_MESSAGE]; (*Event message, when pMsgData is supplied it may contain formatters (%i %d %r %f %s %b) and %% for a literal percent*)
 		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, max 5 of each type (i/r/s/b). 0 writes the message verbatim, with no formatting*)
 	END_VAR
 END_FUNCTION
@@ -44,7 +44,7 @@ END_FUNCTION
 	VAR_INPUT
 		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook the message is added to*)
 		errorID : UINT; (*User defined code written into the event ID*)
-		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, when pMsgData is supplied it may contain formatters (%i %d %r %f %s %b), and %% for a literal percent*)
+		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, when pMsgData is supplied it may contain formatters (%i %d %r %f %s %b) and %% for a literal percent*)
 		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, max 5 of each type (i/r/s/b). 0 writes the message verbatim, with no formatting*)
 	END_VAR
 END_FUNCTION
@@ -54,7 +54,7 @@ END_FUNCTION
 	VAR_INPUT
 		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook the message is added to*)
 		errorID : UINT; (*User defined code written into the event ID*)
-		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, when pMsgData is supplied it may contain formatters (%i %d %r %f %s %b), and %% for a literal percent*)
+		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, when pMsgData is supplied it may contain formatters (%i %d %r %f %s %b) and %% for a literal percent*)
 		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, max 5 of each type (i/r/s/b). 0 writes the message verbatim, with no formatting*)
 	END_VAR
 END_FUNCTION
@@ -63,7 +63,7 @@ END_FUNCTION
 	VAR_INPUT
 		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook the message is added to*)
 		errorID : UINT; (*User defined code written into the event ID*)
-		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, when pMsgData is supplied it may contain formatters (%i %d %r %f %s %b), and %% for a literal percent*)
+		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, when pMsgData is supplied it may contain formatters (%i %d %r %f %s %b) and %% for a literal percent*)
 		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, max 5 of each type (i/r/s/b). 0 writes the message verbatim, with no formatting*)
 	END_VAR
 END_FUNCTION
@@ -72,7 +72,7 @@ END_FUNCTION
 	VAR_INPUT
 		loggerName : STRING[LOG_STRLEN_LOGGERNAME]; (*Name of the logbook the message is added to*)
 		errorID : UINT; (*User defined code written into the event ID*)
-		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, when pMsgData is supplied it may contain formatters (%i %d %r %f %s %b), and %% for a literal percent*)
+		errorString : STRING[LOG_STRLEN_MESSAGE]; (*Message for logger entry, when pMsgData is supplied it may contain formatters (%i %d %r %f %s %b) and %% for a literal percent*)
 		pMsgData : UDINT; (*Address of a StrExtArgs_typ with the format arguments, max 5 of each type (i/r/s/b). 0 writes the message verbatim, with no formatting*)
 	END_VAR
 END_FUNCTION

--- a/src/Ar/LogThat/logManagment.c
+++ b/src/Ar/LogThat/logManagment.c
@@ -25,8 +25,9 @@ signed long createLogInit(plcstring* name, unsigned long size, enum LOG_PERSISTE
 	if(!name) return LOG_ERR_INVALIDINPUT;
 	if(!size) size = LOG_DEFAULT_LOGGERSIZE;
 	
-	// Max strlen of name can not be greater than 10 chars
-	// We should maybe handle this here
+	// Automation Runtime limits logbook names to 10 chars (module name limit),
+	//  and this API's loggerName input is STRING[LOG_STRLEN_LOGGERNAME] (8).
+	// An over-long name is rejected by ArEventLogCreate, not handled here
 	ArEventLogCreate_typ createLog = {};
 	createLog.Execute = 1;
 	strcpy(createLog.Name, (char*)name);

--- a/src/Ar/LogThat/logManagment.c
+++ b/src/Ar/LogThat/logManagment.c
@@ -26,7 +26,7 @@ signed long createLogInit(plcstring* name, unsigned long size, enum LOG_PERSISTE
 	if(!size) size = LOG_DEFAULT_LOGGERSIZE;
 	
 	// Automation Runtime limits logbook names to 10 chars (module name limit),
-	//  and this API's loggerName input is STRING[LOG_STRLEN_LOGGERNAME] (8).
+	//  and the name input is declared STRING[LOG_STRLEN_LOGGERNAME] (8).
 	// An over-long name is rejected by ArEventLogCreate, not handled here
 	ArEventLogCreate_typ createLog = {};
 	createLog.Execute = 1;


### PR DESCRIPTION
Documentation-only companion to the LoupeDocs restructure of the LogThat page (loupeteam/LoupeDocs#116). No behavior changes.

**README** — added a quick start covering logbook creation in `_INIT`, writing entries, formatted messages with `StrExtArgs_typ`, and status handling, plus an explicit dependency list (ArEventLog, AsBrStr, StringExt).

**LogThat.fun** — removed the `PRE-RELEASE` / `Proposed API` banner, which has been inaccurate since 1.0.0, and replaced comments that no longer described the code. Several inputs were documented as "Pointer to string containing name of logger" when they are `STRING` inputs, and `pMsgData` was just "Pointer to format arguments" with no mention that it is a `StrExtArgs_typ` address and optional. Comments now cover the 8 character name limit, `size = 0` falling back to `LOG_DEFAULT_LOGGERSIZE`, the customer bit set internally on event IDs, and the `logDelete` execute/done sequence.

**CHANGELOG** — added the missing 1.0.0 entry (AS6 example project cleanup, StringExt update, package.json for LPM).

## Found while documenting, not fixed here

1. `logStateChange` builds its `StrExtArgs_typ` from `oldState`/`oldStateName` at the top of the function, before the initialization branch seeds them. Its first entry therefore always reads `<Module> start in state  (0)` — empty name, state 0 — regardless of the real starting state. Transitions are fine. The new docs note this as a known quirk; the note comes out with the fix.

2. `src/Ar/LogThat/package.json` declares `"dependencies": {}`, but `ANSIC.lby` requires StringExt 1.0.0+. `lpm install logthat` will not pull StringExt in. The README and docs tell users to install it separately as a workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)