### PR TITLE
fix: report the actual starting state in logStateChange

### DIFF
--- a/src/Ar/LogThat/ANSIC.lby
+++ b/src/Ar/LogThat/ANSIC.lby
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?AutomationStudio FileVersion="4.9"?>
-<Library Version="1.0.0" SubType="ANSIC" xmlns="http://br-automation.co.at/AS/Library">
+<Library Version="1.0.1" SubType="ANSIC" xmlns="http://br-automation.co.at/AS/Library">
   <Files>
     <File Description="Exported data types">Types.typ</File>
     <File Description="Exported constants">Constants.var</File>

--- a/src/Ar/LogThat/CHANGELOG.md
+++ b/src/Ar/LogThat/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change log
 
+- 1.0.1 - Fix logStateChange reporting state 0 in its first entry instead of the state present on the first call
 - 1.0.0 - Raise the minimum StringExt version from 0.14.1 to 1.0.0
     - Update the example project for AS6: remove AsArLog, AsDb, AsSafety, Convert, LoopConR, MTTypes and the Motion libraries, none of which the library uses
     - Update StringExt in the example project to the released 1.0.0

--- a/src/Ar/LogThat/logStateChange.c
+++ b/src/Ar/LogThat/logStateChange.c
@@ -25,12 +25,26 @@
 // Monitor a state variable and log changes
 //------------------------------------------
 
-// First call - looks good
-// Other calls - 
-
 void logStateChange(struct logStateChange* inst) {
 	
 	StrExtArgs_typ LogData;
+	unsigned char firstCall = !inst->initialized;
+	
+	// Seed defaults and stored state before building LogData, so the start
+	//  message reports the state present on the first call
+	if (firstCall) {
+		
+		// Default logger and module name
+		if (strcmp(inst->LoggerName, "") == 0) strcpy(inst->LoggerName, "State");	
+		if (strcmp(inst->ModuleName, "") == 0) strcpy(inst->ModuleName, "State");
+		
+		// Initialize old data
+		inst->oldState = inst->State;
+		strcpy(inst->oldStateName, inst->StateName);
+		
+	}
+	
+	memset(&LogData, 0, sizeof(LogData));
 	
 	LogData.i[0]= (DINT)inst->oldState;
 	LogData.i[1]= (DINT)inst->State;
@@ -40,19 +54,9 @@ void logStateChange(struct logStateChange* inst) {
 	LogData.s[2]= (UDINT)inst->StateName;
 	
 	// First call
-	if (!inst->initialized) {
-		
-		// Default logger and module name
-		// TODO: This seems like a bad default given the changes
-		if (strcmp(inst->LoggerName, "") == 0) strcpy(inst->LoggerName, "State");	
-		if (strcmp(inst->ModuleName, "") == 0) strcpy(inst->ModuleName, "State");
-	
-		// Initialize old data
-		inst->oldState = inst->State;
-		strcpy(inst->oldStateName, inst->StateName);
+	if (firstCall) {
 		
 		if (strcmp(inst->StateName, "") == 0) {
-			// TODO: msgData is not currently supported
 			inst->Status = logInfo(inst->LoggerName, 0, "%s start in state %i", (UDINT)&LogData);
 		} else {
 			inst->Status = logInfo(inst->LoggerName, 0, "%s start in state %s (%i)", (UDINT)&LogData);


### PR DESCRIPTION
`logStateChange` copied `oldState` into its `StrExtArgs_typ` at the top of the function, before the initialization branch seeded it from the current input. On the first call that value was still `0`, so the start entry reported state `0` no matter what `State` actually was:

```
Infeed start in state Running (0)
```

The state **name** was unaffected: `s[1]` holds a pointer to `oldStateName`, and the `strcpy` that seeds it runs before `logInfo`, so only the numeric state was stale. Transition entries were correct and are unchanged.

The fix seeds the defaults and the stored state first, then builds the message arguments, so the start entry now reads `Infeed start in state Running (5)`. Also zeroed the argument struct before use, and dropped two stale TODOs — one claimed `msgData` was unsupported, which it is not.

Bumped to 1.0.1 in `ANSIC.lby` with a changelog entry. Happy to drop the version bump if you'd rather do it at release time. `package.json` deliberately stays at `0.0.0`: the publish workflow regenerates it from the release tag, so the in-repo value is never published.

**Base branch**: stacked on `docs/logthat-reference` (#7) so the changelog edits don't conflict. GitHub will retarget this to `main` once that merges, and it should merge second.

The matching docs note is in loupeteam/LoupeDocs#116.

Not verified by a build — no Automation Studio in this environment, so this is reviewed by inspection only. Reviewers confirmed the traced behavior against StringExt's `formatString`, the unchanged transition path, C89 declaration order, and that the first call cannot also emit a transition entry for any initial `State`.

**Correction**: an earlier version of this description said the start entry also showed an empty state name. That was wrong — the name rendered correctly in 1.0.0. Only the state number was affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)